### PR TITLE
Allow arrow keys and other keyboard shortbuts to exit Search Mode when in GETCH_INPUT mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(GETCH_INPUT)
 endif()
 
 # Add source to this project's executable.
-add_executable (QuickLookupExample  "QuickLookup.h" "Example.cpp" "ClipboardWin.h" "ClipboardLin.h")
+add_executable (QuickLookupExample  "QuickLookup.h" "Example.cpp" "ClipboardWin.h" "ClipboardLin.h" "Navigation.h")
 
 if (CMAKE_VERSION VERSION_GREATER 3.12)
   set_property(TARGET QuickLookupExample PROPERTY CXX_STANDARD 20)

--- a/ClipboardWin.h
+++ b/ClipboardWin.h
@@ -33,6 +33,7 @@ namespace ClipboardUtils {
 		HGLOBAL globMem = GlobalAlloc(GMEM_MOVEABLE, sizeof(s));
 		if (globMem==0) throw "Failed to allocate memory for clipboard";
 		HGLOBAL writeableMem =  GlobalLock(globMem);
+		if (writeableMem == 0) throw "Failed to lock memory for clipboard";
 		memcpy(writeableMem, s.c_str(), sizeof(s));
 		GlobalUnlock(globMem);
 		OpenClipboard(0);

--- a/Navigation.h
+++ b/Navigation.h
@@ -1,0 +1,89 @@
+#if(WIN32)
+#include<conio.h>
+#else
+#include<stdio.h>
+#endif
+
+using namespace std;
+namespace QLNav {
+
+	enum NavType {
+		MOVE_UP,
+		MOVE_DOWN,
+		GO_UPMOST,
+		GO_DOWNMOST,
+		SEARCH,
+		COPY_AND_QUIT,
+		BACKSPACE,
+		UNDEFINED,
+		PRINTABLE_CHARACTER,
+		CONTROL_SEQUENCE
+	};
+
+	struct NavAction {
+		NavType type;
+		int navValue;
+	};
+
+	NavAction processKey(int key, bool control_sequence=false) {
+		//If previous input was control sequence, now process second code
+		NavType type;
+		if (control_sequence) {
+			switch (key) { // SECOND ARROW KEY CALL
+			case 0x48: // UP ARROW
+			case 0x4B: // LEFT ARROW
+				type = MOVE_UP;
+				break;
+			case 0x50: // DOWN ARROW
+			case 0x4D: // RIGHT ARROW
+				type = MOVE_DOWN;
+				break;
+			case 0x47: // HOME
+			case 0x49: // PG UP
+				type = GO_UPMOST;
+				break;
+			case 0x4F: // END
+			case 0x51: // PG DOWN
+				type = GO_DOWNMOST;
+				break;
+			default:
+				type = UNDEFINED;
+				break;
+			}
+			return NavAction(type, 0xe000 + key); // Return full key code including control sequence
+		} 
+		//If this key is not part of a control sequence, process key
+		switch (key) {
+		case 0x0D: // ENTER; GO Down
+			type = MOVE_DOWN;
+			break;
+		case 0x03: // CTRL+C; Copy and Quit QL 
+			type = COPY_AND_QUIT;
+			break;
+		case 0x1A: // CTRL+Z; Search Again
+			type = SEARCH;
+			break;
+		case 0x08: // BACKSPACE
+			type = BACKSPACE;
+			break;
+		case 0xe0: // First Special key codes
+		case 0x00:
+			type = CONTROL_SEQUENCE;
+			break;
+		default:
+			if (0x20 <= key && key <= 0x7e) type = PRINTABLE_CHARACTER;
+			else type = UNDEFINED;
+			break;
+		}
+		return NavAction(type, key);
+	}
+
+	NavAction readAction() {
+		NavAction action = processKey(_getch(), false);
+		if (action.type == CONTROL_SEQUENCE) {
+			//If control sequence, process second code
+			action = processKey(_getch(), true);
+		}
+		return action;
+	}
+}

--- a/QuickLookup.h
+++ b/QuickLookup.h
@@ -118,18 +118,20 @@ namespace QL {
 		*/
 		void lookup(string);
 
-		//Get search string from user and lookup results
+		//Enter Search mode, get search string from user and lookup results
 		void search() {
 			selectedRow = -1;
 			update_search_results();
 			set_cursor_to_search();
+
 #if(GETCH_INPUT)
+
 			string s;
 			char c;
-			//Keep getting characters until ENTER or CTRL+C
-			while ((c = _getch()) != 0x0D && c != 0x3) {
+			// Keep getting characters until ENTER, CTRL+C, DOWN ARROW or RIGHT ARROW is pressed.
+			while ((c = _getch()) != 0x0D && c != 0x3 && c != 0x50 && c != 0x4D) {
 				set_cursor_to_search((int)s.length() + 1);
-				//Handles backspace
+				// Handles backspace
 				if (c == 0x08) { //BACKSPACE
 					if (!s.empty()) {
 						s.pop_back();
@@ -137,27 +139,31 @@ namespace QL {
 						cout << ' ';
 					}
 				}
-				//Stop handling characters after max length has been reached.
+				// Stop handling characters after max length has been reached.
 				else if (s.length() == windowWidth - 2 * windowMargin) continue;
-				//Prints printable characters
+				// Prints printable characters
 				else if(0x20<=c && c<=0x7e) {
 					s += c;
 					cout << c;
 				}
-				//Handle Control Sequence
+				// Handle Control Sequence
 				else if (c == 0x0 || (uint8_t)c == 0xE0) {
-					//Consume Scan Code and Do Nothing
-					_getch();
+					// Special return value is consumed
+					// next iteration will process the second byte of the sequence.
 					continue;
 				}
 				lookup(s);
 				update_search_results();
 		}
+
 #else
+
 			string s;
 			getline(cin, s);
 			lookup(s);
+
 #endif
+
 			navigate_upmost();
 		}
 

--- a/QuickLookup.h
+++ b/QuickLookup.h
@@ -149,7 +149,7 @@ namespace QL {
 			string s;
 			getline(cin, s);
 			lookup(s);
-			return QLNav::MOVE_DOWN;
+			return QLNav::NavAction(QLNav::MOVE_DOWN, 0);
 #endif
 		}
 


### PR DESCRIPTION
- [x] `DOWN_ARROW` and `RIGHT_ARROW` now exit Search mode similarly to `ENTER`
- [x] `UP_ARROW`  and `LEFT_ARROW` should exit Search mode with their respective actions
- [x] `PG_UP`/`DOWN` and `HOME`/`END` keys should exit Search mode with their respective actions

Potentially refactor `QuickLookup::run()` so that `QuickLookup::Search()` does not need to process the first key press